### PR TITLE
FIX bug with CTRL+D in input

### DIFF
--- a/game.c
+++ b/game.c
@@ -65,11 +65,16 @@ char get_letter_from_user() {
             if (isalpha(input)) {
                 break;
             } else {
+                while (getchar() != '\n' && !feof(stdin));
                 printf("Invalid input. Please enter a letter: ");
             }
-        } else {
+        } else if(feof(stdin)) {
+            clearerr(stdin);
+            printf("\nInvalid input. Please enter a letter: ");
+        } 
+        else {
             // Clear the input buffer on invalid input
-            while (getchar() != '\n');
+            while (getchar() != '\n' && feof(stdin));
             printf("Invalid input. Please enter a letter: ");
         }
     }

--- a/game.c
+++ b/game.c
@@ -74,7 +74,7 @@ char get_letter_from_user() {
         } 
         else {
             // Clear the input buffer on invalid input
-            while (getchar() != '\n' && feof(stdin));
+            while (getchar() != '\n' && !feof(stdin));
             printf("Invalid input. Please enter a letter: ");
         }
     }


### PR DESCRIPTION
When the user presses `Ctrl+D` (EOF) during input, `scanf` fails and sets the EOF flag on `stdin`. As long as this flag is set, all subsequent input attempts using `scanf` will fail immediately, causing the program to get stuck or behave unexpectedly.

Fix:

We call `clearerr(stdin)` to reset the `EOF ` flag after detecting it. This allows the program to continue prompting the user for input, even after `Ctrl+D` was pressed, without exiting or freezing.